### PR TITLE
Moved photoOutput ivar to protected

### DIFF
--- a/framework/Source/GPUImageStillCamera.h
+++ b/framework/Source/GPUImageStillCamera.h
@@ -4,6 +4,10 @@ void stillImageDataReleaseCallback(void *releaseRefCon, const void *baseAddress)
 void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize finalSize, CMSampleBufferRef *sampleBuffer);
 
 @interface GPUImageStillCamera : GPUImageVideoCamera
+{
+	@protected
+	AVCaptureStillImageOutput *photoOutput;
+}
 
 /** The JPEG compression quality to use when capturing a photo as a JPEG.
  */

--- a/framework/Source/GPUImageStillCamera.m
+++ b/framework/Source/GPUImageStillCamera.m
@@ -42,9 +42,6 @@ void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize fina
 }
 
 @interface GPUImageStillCamera ()
-{
-    AVCaptureStillImageOutput *photoOutput;
-}
 
 // Methods calling this are responsible for calling dispatch_semaphore_signal(frameRenderingSemaphore) somewhere inside the block
 - (void)capturePhotoProcessedUpToFilter:(GPUImageOutput<GPUImageInput> *)finalFilterInChain withImageOnGPUHandler:(void (^)(NSError *error))block;


### PR DESCRIPTION
otherwise it's not available  in the `EYEStillCamera` subclass when building for Xcode 7
